### PR TITLE
Add calibration scene and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Volumetric Display Project
+
+## Prerequisites
+
+Make sure you have the following tools installed:
+
+- [Bazelisk](https://github.com/bazelbuild/bazelisk)
+- [Python 3.x](https://www.python.org/)
+
+## Building the Project
+
+Navigate to the project directory and build the project using Bazelisk:
+
+```sh
+bazelisk build //:main
+```
+
+## Running the Simulator
+
+To run the volumetric display simulator, use the following command:
+
+```sh
+bazelisk run //:main -- --geometry=20x20x20 --ip=127.0.0.1 --port=6454 --universes-per-layer=6
+```
+
+You can adjust the `--geometry`, `--ip`, `--port`, and `--universes-per-layer` arguments as needed.
+
+## Running a Scene
+
+To run a specific scene, you can use a Python script like `manual.py`. Here is an example command:
+
+```sh
+python3 manual.py --scene=rainbow_scene.py --geometry=20x20x20 --ip=127.0.0.1 --port=6454
+```
+
+Replace `rainbow_scene.py` with the scene file name.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Make sure you have the following tools installed:
 
 - [Bazelisk](https://github.com/bazelbuild/bazelisk)
+- [Nix](https://nixos.org/download/)
 - [Python 3.x](https://www.python.org/)
 
 ## Building the Project

--- a/calibration_scene.py
+++ b/calibration_scene.py
@@ -1,0 +1,27 @@
+from artnet import Scene, RGB
+import math
+
+white = RGB(255, 255, 255)
+red = RGB(255, 0, 0)
+blue = RGB(0, 0, 255)
+green = RGB(0, 255, 0)
+black = RGB(0, 0, 0)
+
+class CalibrationScene(Scene):
+    def render(self, raster, time):
+        for y in range(raster.height):
+            for x in range(raster.width):
+                for z in range(raster.length):
+                    idx = y * raster.width + x + z * raster.width * raster.height
+
+                    
+                    color = black
+                    if x == 0:
+                        color = red
+                    elif y == 0:
+                        color = green
+                    elif z == 0:
+                        color = blue
+                    
+                    raster.data[idx] = color
+                    

--- a/simulator.py
+++ b/simulator.py
@@ -367,7 +367,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--geometry',
                         type=str,
-                        default="16x16x16",
+                        default="20x20x20",
                         help="Width, height, and length of the display")
     parser.add_argument('--ip',
                         type=str,


### PR DESCRIPTION
The default in the simulator was `16x16x16` when the default in `manual.py` was `20x20x20`. Took me a while to figure it out and this calibration scene helped 😄 so checking it in with a readme and fix to the simulator default.
<img width="912" alt="Screenshot 2024-12-30 at 7 28 37 PM" src="https://github.com/user-attachments/assets/cafb0008-39d2-427b-8953-2f3374f4a50f" />
<img width="912" alt="Screenshot 2024-12-30 at 7 44 19 PM" src="https://github.com/user-attachments/assets/dab125c3-d2e1-4357-8c5e-1de9d7382b78" />
